### PR TITLE
Cpu update

### DIFF
--- a/CPU/Components/CU.js
+++ b/CPU/Components/CU.js
@@ -441,18 +441,67 @@ function fetch(){ // Get instuction from memory and load into the correct regist
 function getOperand(){ // Put operand data into MDR ready for instruction execution
   if (expanded_memory == true){
     if (mode == "1"){ // Operand is memory address, actual data must be fetched
-      var oprLen = parseInt(CIR.slice(5, 8).join(""), 2);  // Get number of bytes used by address
-      subqueue = [
-        "CONTROLBUS.read = 1",
-        "loadOperand(MAR);",
-        "updateBus(ADDRESSBUS, MAR)",
-        "getAddress()",
-        "dataRequest()",
-        "busGrant()",
-        "outputData()",
-        "update(MDR)",
-        "CONTROLBUS.read = 0"
-      ]
+      if ([allowedInstructions[6][0], allowedInstructions[7][0], allowedInstructions[8][0], allowedInstructions[9][0], allowedInstructions[10][0], allowedInstructions[11][0], allowedInstructions[12][0]].includes(opcode)){
+        // Instruction is one that takes an address (RED, WRT, GTO, BIZ, BIN, BIO, BIC) and mode is 1 so it takes an address of an address
+        // As addresses are 4 bytes, load the 4 bytes starting from the one specified in operand into MDR
+        subqueue = [
+          // Load value of first byte into MDR
+          "CONTROLBUS.read = 1",
+          "loadOperand(MAR);",
+          "updateBus(ADDRESSBUS, MAR)",
+          "getAddress()",
+          "dataRequest()",
+          "busGrant()",
+          "outputData()",
+          "updatePart(MDR, 0)",
+          "CONTROLBUS.read = 0",
+          // Increment the MAR for second byte
+          "increment(MAR)",
+          "updateBus(ADDRESSBUS, MAR)",
+          "CONTROLBUS.read = 1",
+          "getAddress()",
+          "dataRequest()",
+          "busGrant()",
+          "outputData()",
+          "updatePart(MDR, 8)",
+          "CONTROLBUS.read = 0",
+          // Third byte
+          "increment(MAR)",
+          "updateBus(ADDRESSBUS, MAR)",
+          "CONTROLBUS.read = 1",
+          "getAddress()",
+          "dataRequest()",
+          "busGrant()",
+          "outputData()",
+          "updatePart(MDR, 16)",
+          "CONTROLBUS.read = 0",
+          // Fourth byte
+          "increment(MAR)",
+          "updateBus(ADDRESSBUS, MAR)",
+          "CONTROLBUS.read = 1",
+          "getAddress()",
+          "dataRequest()",
+          "busGrant()",
+          "outputData()",
+          "updatePart(MDR, 24)",
+          "CONTROLBUS.read = 0",
+        ];
+      }
+      else{
+        var oprLen = parseInt(CIR.slice(5, 8).join(""), 2);  // Get number of bytes used by address
+        subqueue = [
+          "CONTROLBUS.read = 1",
+          "loadOperand(MAR);",
+          "updateBus(ADDRESSBUS, MAR)",
+          "getAddress()",
+          "dataRequest()",
+          "busGrant()",
+          "outputData()",
+          "update(MDR)",
+          "CONTROLBUS.read = 0"
+        ]
+      }
+      
 
   }
   else{

--- a/CPU/Components/registers.js
+++ b/CPU/Components/registers.js
@@ -40,6 +40,12 @@ function update(register){ // Put contents of DATABUS into given array
 }
 }
 
+function updatePart(register, offset){  // Put contents of DATABUS into given array starting at specific offset (for 32 bit mode only)
+  for (var i = 0; i < 8; i++){
+    register[offset + i] = parseInt(DATABUS[i], 2);
+  }
+}
+
 function rotate(register, times, direction){  // Shift bits a given number of places in a given direction
   if (direction == "l"){  // Rotate left
     for (var i = 0; i < times; i++){

--- a/CPU/Interface/ui.js
+++ b/CPU/Interface/ui.js
@@ -80,9 +80,9 @@ function start(){
     // Get operand
     word = word.replace(/[^0-9]/g, ""); // Remove any non numerical chars to leave only operand
     var wdlen = word.length;
-    if (!(0 < wdlen <= 3)){
-      if (opc == allowedInstructions[5, 0] || opc == allowedInstructions[13, 0]
-      || opc == allowedInstructions[14, 0] || opc == allowedInstructions[15, 0]){ // Opcode is not, out, inp or end (does not require operand)
+    if (!(0 < wdlen && wdlen <= 3)){
+      if (opc == allowedInstructions[5][0] || opc == allowedInstructions[13][0]
+      || opc == allowedInstructions[14][0] || opc == allowedInstructions[15][0]){ // Opcode is not, out, inp or end (does not require operand)
         word = "000";
       }
       else{
@@ -687,10 +687,10 @@ function start_expanded_mode(){
     // Get operand
     word = word.replace(/[^0-9]/g, ""); // Remove any non numerical chars to leave only operand
     var wdlen = word.length;
-    if (!(0 < wdlen <= 3)){
-      if (opc == allowedInstructions[5, 0] || opc == allowedInstructions[13, 0]
-      || opc == allowedInstructions[14, 0] || opc == allowedInstructions[15, 0]){ // Opcode is not, out, inp or end (does not require operand)
-        word = "000";
+    if (!(0 < wdlen && wdlen <= 3)){
+      if (opc == allowedInstructions[5][0] || opc == allowedInstructions[13][0]
+      || opc == allowedInstructions[14][0] || opc == allowedInstructions[15][0]){ // Opcode is not, out, inp or end (does not require operand)
+        word = "none";
       }
       else{
         badInput(word, line) // Operand is either too small or too big (or not given)
@@ -701,28 +701,26 @@ function start_expanded_mode(){
     // Convert operand to binary
     if (Number(opr) < 4294967296){
       opr = Number(opr).toString(2);
-      var neededZeroes = (8 - (opr.length % 8)) % 8;  // Get number of zeroes needed.  8 - First mod operation gets the number of bits needed to the next full byte, second mod turns this to 0 if it is 8
-      var prestr = "";
-      for (var i = 0; i < neededZeroes; i++){
-        prestr = prestr + "0";
+      // If the operand is an address (if mode is A or the instruction takes an address as data e.g. GTO) then the operand will use 4 bytes, else it will use 1
+      if (mode == "1" || [allowedInstructions[6][0], allowedInstructions[7][0], allowedInstructions[8][0], allowedInstructions[9][0], allowedInstructions[10][0], allowedInstructions[11][0], allowedInstructions[12][0]].includes(opc)){
+        // Right pad to 32 bits
+        opr = opr.padStart(32, "0");
+        var oprLength = "100";
       }
-      opr = prestr.concat(opr);
-      var oprLength = Math.ceil(opr.length / 8);  // Get number of bytes needed for operand
+      else{
+        // Right pad to 8 bits
+        opr = opr.padStart(8, "0");
+        var oprLength = "001";
+      }
     }
-    else {
+    else if (word === "none"){
+      // There is no operand, as the opcode does not need one
+      oprLength = "000";
+      opr = "";
+    }
+    else{
       badInput(opr, line);
     }
-
-    // Convert byte length to 3 bit binary
-    oprLength = Number(oprLength).toString(2);
-    var tmp = (3 - oprLength.length);
-    var prestr = "";
-    for (var i = 0; i < tmp; i++){
-      prestr = prestr + "0";
-    }
-    oprLength = prestr.concat(oprLength);
-
-
     // Combine into one machine instruction
     word = opc.concat(mode, oprLength, opr);
     var command = [];

--- a/CPU/Interface/ui.js
+++ b/CPU/Interface/ui.js
@@ -729,13 +729,13 @@ function start_expanded_mode(){
     // Get operand
     word = word.replace(/[^0-9]/g, ""); // Remove any non numerical chars to leave only operand
     var wdlen = word.length;
-    if (!(0 < wdlen && wdlen <= 3)){
+    if (wdlen <= 0){
       if (opc == allowedInstructions[5][0] || opc == allowedInstructions[13][0]
       || opc == allowedInstructions[14][0] || opc == allowedInstructions[15][0]){ // Opcode is not, out, inp or end (does not require operand)
         word = "none";
       }
       else{
-        badInput(word, line) // Operand is either too small or too big (or not given)
+        badInput(word, line) // Operand is not given
     }
     }
     opr = word;


### PR DESCRIPTION
Made changes to the CPU:

- Added labels to assembler, this makes goto instructions easier as the assmbler will work out the address of the target instruction so the user does not have to
- In 32 bit mode, instruction lengths are now less variable
    - Instructions with no operand (NOT, INP, END, and OUT (OUT only when addressing mode is D) now only use 1 byte
    - Instructions that take an address as an operand (RED, WRT, GTO, BIZ, BIC, BIN, BIO, and other instructions when addressing mode is A) now always take 5 bytes (addresses in operands previously only used as many bytes as needed)
    - All others use 2 bytes
- RED, WRT, GTO, BIC, BIN, BIZ, BIO now work properly with addressing mode A in 32 bit mode (the address given as operand will be the address of the first byte of the address)